### PR TITLE
Fixes bugs

### DIFF
--- a/src/hijacks.asm
+++ b/src/hijacks.asm
@@ -307,7 +307,7 @@ ORG !_F+$008650
         RTS
 
 ; run at the very start of the game, to make sure the option save data is not corrupt
-ORG !_F+$00940F
+ORG !_F+$009391
         JSR check_option_bounds_hijack
 
 ; run at the very start of level load
@@ -366,8 +366,7 @@ overworld_late_load_hijack:
         JMP $93F4
 check_option_bounds_hijack:
         JSL failsafe_check_option_bounds
-        DEC $1DF5
-        RTS
+        JMP $85FA
 
 ; 'fix' PI with this convoluted hijack
 ORG !_F+$01F203

--- a/src/hijacks.asm
+++ b/src/hijacks.asm
@@ -375,7 +375,7 @@ ORG !_F+$01F203
         NOP #2
         
 ; 'fix' item swap
-ORG !_F+$01C53B
+ORG !_F+$01C550
         JSL fix_item_swap_bug
 
 ; on goal tape trigger

--- a/src/level_tick.asm
+++ b/src/level_tick.asm
@@ -1897,10 +1897,10 @@ fix_powerup_incrementation:
         PEA $F24F-1
         RTL
 
-; fix item swap bug by reverting the program bank if item index is out of bounds
+; fix item swap bug by reverting the program bank if pointer index is out of bounds
 ; open bus behavior requires program bank to be $01, not $81
 fix_item_swap_bug:
-        CMP #$05
+        CMP #$06
         BCC .done
         PHA
         LDA $04,S
@@ -1908,9 +1908,7 @@ fix_item_swap_bug:
         STA $04,S
         PLA
     .done:
-        ASL #2
-        ORA $19
-        RTL
+        JML !_F+$0086DF ; ExecutePtr
 
 ; activate orb flag if level beaten with orb that came out of the item box
 collect_orb:

--- a/src/region_differences.asm
+++ b/src/region_differences.asm
@@ -1201,7 +1201,8 @@ pal_bowser_data_6:
 pal_l2_1:
         PHA
         LDA.L !status_region
-        CMP #$02
+        AND #$00FF
+        CMP #$0002
         PLA
         BCC +
         CLC


### PR DESCRIPTION
* Reverting the program bank if pointer index is out of  bounds regardless of item index.
* Fixed a BSoD when entering the third room of VoB2.
* Moved check_option_bounds_hijack from the beginning of GameMode01 to the beginning of GameMode00,
because the status_region bounds should be checked before calling nintendo_presents.