### PR TITLE
add rng meter

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -57,6 +57,10 @@
 !restore_room_xpos           = $19F3 ; 2 bytes, 16-bit value
 !restore_room_dragoncoins    = $19F5
 !restore_room_tide           = $19F6
+!restore_room_rng_index      = $0DDB ; 3 bytes
+
+; rng index
+!rng_index                   = $1487 ; 3 bytes
 
 ; determines when to load state from different level
 !load_state_timer            = $0EF9

--- a/src/hijacks.asm
+++ b/src/hijacks.asm
@@ -495,6 +495,10 @@ ORG !_F+$01AAAC
         JSL set_shell_speed_lda
         NOP
 
+; count rng index
+ORG !_F+$01ACFC
+        JSL count_rng_index
+
 ; roulette item speed
 ORG !_F+$01C31C
         JSL set_roulette_speed

--- a/src/level_load.asm
+++ b/src/level_load.asm
@@ -124,6 +124,12 @@ setup_room_reset:
         STA $D2 ; mario x position high byte
         LDA !restore_room_tide
         STA $1B9D ; layer 3 tide timer
+        LDA !restore_room_rng_index
+        STA !rng_index
+        LDA !restore_room_rng_index+1
+        STA !rng_index+1
+        LDA !restore_room_rng_index+2
+        STA !rng_index+2
         
         LDX #$03
       - LDA !restore_room_boo_ring,X
@@ -178,6 +184,9 @@ setup_level_reset:
         LDA !restore_level_xpos+1
         STA $D2 ; mario x position high byte
         STZ $1B9D ; layer 3 tide timer
+        STZ !rng_index
+        STZ !rng_index+1
+        STZ !rng_index+2
         
         ; set msb so it's not 00, which is a special case for entering the level
         ; we'll turn this byte into fnnnnnnn, f = 0 if just entered level, n = sublevel count
@@ -326,6 +335,12 @@ save_room_properties:
         DEX
         BPL -
         
+        LDA !rng_index
+        STA !restore_room_rng_index
+        LDA !rng_index+1
+        STA !restore_room_rng_index+1
+        LDA !rng_index+2
+        STA !restore_room_rng_index+2
         LDA !level_timer_minutes
         STA !restore_level_timer_minutes
         LDA !level_timer_seconds
@@ -754,7 +769,7 @@ init_statusbar_properties:
         dw .movie_recording
         dw .memory_7e
         dw .memory_7f
-        dw .rtc
+        dw .rng
         
     .mario_speed:
         LDA #$2C
@@ -853,9 +868,13 @@ init_statusbar_properties:
         LDA.L name_colors,X
         JMP .store_4
     
-    .rtc:
-        LDA #$2C
-        JMP .store_8
+    .rng:
+        LDA [!statusbar_layout_ptr],Y
+        PHP
+        LDA #$38
+        PLP
+        BEQ .store_5
+        JMP .store_4
         
     .store_8:
         STA [$00]

--- a/src/option_text.asm
+++ b/src/option_text.asm
@@ -241,7 +241,7 @@ meter_names:
         db "RECORD LIMIT    "
         db "MEMORY VIEWER   "
         db "MEMORY VIEWER   "
-        db "REALTIME CLOCK  "
+        db "RANDOM NUMBER   "
 
 meter_types:
         dw meter_text_none
@@ -263,7 +263,7 @@ meter_types:
         dw meter_text_record
         dw meter_text_none
         dw meter_text_none
-        dw meter_text_rtc
+        dw meter_text_rng
         
 meter_text_none:
         db "                "
@@ -298,10 +298,10 @@ meter_text_name:
 meter_text_record:
         db "    VISUAL      "
         db "   NUMERIC      "
-meter_text_rtc:
-        db "   UP-TIME      "
-        db "   24-HOUR      "
-        db "   12-HOUR      "
+meter_text_rng:
+        db "     INDEX      "
+        db "     VALUE      "
+        db "      SEED      "
 
 meter_description:
         db "                                "
@@ -380,7 +380,7 @@ meter_description:
         db "  WORK RAM AT THIS ADDRESS      "
         db "  OF BANK 7Fh                   "
         db "                                "
-        db "  CLOCK ONLY AVAILABLE ON RTC   "
-        db "  ENABLED SYSTEMS               "
-        db "                                "
-        db "  UP-TIME SINCE POWER ON        "
+        db "  DISPLAYS THE CURRENTLY        "
+        db "  HELD VALUE ON THE             "
+        db "  RANDOM NUMBER GENERATOR       "
+        db "  OR INDEX OF THE VALUE         "

--- a/src/overworld_menu.asm
+++ b/src/overworld_menu.asm
@@ -1644,7 +1644,7 @@ meter_editor_mode: ; w$5460
         LDA [!statusbar_layout_ptr],Y
         DEC A
         BPL +
-        LDA #$12 ; number of meters
+        LDA #$13 ; number of meters
       + STA [!statusbar_layout_ptr],Y
         LDA #$00
         INY
@@ -1694,7 +1694,7 @@ meter_editor_mode: ; w$5460
         TAY
         LDA [!statusbar_layout_ptr],Y
         INC A
-        CMP #$13 ; number of meters + 1
+        CMP #$14 ; number of meters + 1
         BNE +
         LDA #$00
       + STA [!statusbar_layout_ptr],Y
@@ -2090,7 +2090,7 @@ meter_widths:
         db $07,$04,$FF,$FF,$FF,$FF,$FF,$FF
         db $02,$FF,$FF,$FF,$FF,$FF,$FF,$FF
         db $02,$FF,$FF,$FF,$FF,$FF,$FF,$FF
-        db $08,$08,$08,$FF,$FF,$FF,$FF,$FF
+        db $05,$04,$04,$FF,$FF,$FF,$FF,$FF
 meter_heights:
         db $FF,$FF,$FF,$FF,$FF,$FF,$FF,$FF
         db $04,$FF,$FF,$FF,$FF,$FF,$FF,$FF
@@ -2388,7 +2388,7 @@ draw_edited_status_bar:
         dw .edited_movie_recording
         dw .edited_memory_7e
         dw .edited_memory_7f
-        dw .edited_rtc
+        dw .edited_rng
         
     .edited_item_box:
         LDA $03
@@ -2905,14 +2905,26 @@ draw_edited_status_bar:
         STA [$00],Y
         RTS
         
-    .edited_rtc:
+    .edited_rng:
+        PHY
+        LDA $05,S
+        TAY
+        INY
+        LDA [!statusbar_layout_ptr],Y
+        AND #$00FF
+        PLY
+        ASL A
+        TAX
+        JMP (.rng_types,X)
+    .rng_types:
+        dw .rng_types_index
+        dw .rng_types_value
+        dw .rng_types_seed
+    .rng_types_index
         LDA #$3801
         STA [$00],Y
         INY #2
         LDA #$3802
-        STA [$00],Y
-        INY #2
-        LDA #$3878
         STA [$00],Y
         INY #2
         LDA #$3803
@@ -2921,13 +2933,18 @@ draw_edited_status_bar:
         LDA #$3804
         STA [$00],Y
         INY #2
-        LDA #$3878
-        STA [$00],Y
-        INY #2
         LDA #$3805
         STA [$00],Y
+        RTS
+    .rng_types_value
+    .rng_types_seed
+        LDA #$3800
+        STA [$00],Y
         INY #2
-        LDA #$3806
+        STA [$00],Y
+        INY #2
+        STA [$00],Y
+        INY #2
         STA [$00],Y
         RTS
 


### PR DESCRIPTION
Added the feature to display the number of times a random number has been generated since the level was started.
(The count is reset when the random number completes a cycle and the seed value reaches 0.)

This feature would be useful for research and practice in random number adjustment in Lemmy's Castle.

I have chosen two addresses to store the counts from unused RAM.
If you find a more appropriate location, please change it.